### PR TITLE
Update UIColor+HexColors.m

### DIFF
--- a/UIColor+HexColors.m
+++ b/UIColor+HexColors.m
@@ -18,7 +18,7 @@
     
     // Brutal and not-very elegant test for non hex-numeric characters
     NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"[^a-fA-F|0-9]" options:0 error:NULL];
-    NSUInteger match = [regex numberOfMatchesInString:hexString options:NSMatchingCompleted range:NSMakeRange(0, [hexString length])];
+    NSUInteger match = [regex numberOfMatchesInString:hexString options:NSMatchingReportCompletion range:NSMakeRange(0, [hexString length])];
     
     if (match != 0) {
         return nil;


### PR DESCRIPTION
Fixed the warning:

Implicit conversion from enumeration type 'enum NSMatchingFlags' to different enumeration type 'NSMatchingOptions' (aka 'enum NSMatchingOptions')
